### PR TITLE
Fix Triangle Count

### DIFF
--- a/Assets/Scripts/Editor/Tools/GetSelectedMeshInfo.cs
+++ b/Assets/Scripts/Editor/Tools/GetSelectedMeshInfo.cs
@@ -31,7 +31,7 @@ namespace UnityLibrary
                 for (int i = 0, length = meshes.Length; i < length; i++)
                 {
                     totalVertices += meshes[i].sharedMesh.vertexCount;
-                    totalTris += meshes[i].sharedMesh.triangles.Length;
+                    totalTris += meshes[i].sharedMesh.triangles.Length / 3;
                     totalMeshes++;
                 }
 


### PR DESCRIPTION
sharedMesh.triangles returns an array of integers that are actually triplets of indices that references different vertices of the mesh. Therefore the total tri count would be the length of the array divided by 3.