### PR TITLE
Made ScreenEdgeColliders more efficient. AddCollider() is more effici…

### DIFF
--- a/Assets/Scripts/2D/Colliders/ScreenEdgeColliders.cs
+++ b/Assets/Scripts/2D/Colliders/ScreenEdgeColliders.cs
@@ -1,35 +1,73 @@
 // adds EdgeCollider2D colliders to screen edges
 // only works with orthographic camera
 
+//Includes two different ways of implementation into your project
+//One is a method that uses cached fields on Awake() that requires this entire class but is more slightly more efficient (should use this if you plan to use the method in Update())
+//The other is a standalone method that doesn't need the rest of the class and can be copy-pasted directly into any project but is slightly less efficient
+
 using UnityEngine;
-using System.Collections;
 
 namespace UnityLibrary
 {
-  public class ScreenEdgeColliders : MonoBehaviour 
-  {
-    void Awake () 
+    public class ScreenEdgeColliders : MonoBehaviour
     {
-      AddCollider();
+        Camera cam;
+        EdgeCollider2D edge;
+        Vector2[] edgePoints;
+
+        void Awake()
+        {
+            if (Camera.main == null) Debug.LogError("Camera.main not found, failed to create edge colliders");
+            else cam = Camera.main;
+
+            if (!cam.orthographic) Debug.LogError("Camera.main is not Orthographic, failed to create edge colliders");
+
+            // add or use existing EdgeCollider2D
+            edge = GetComponent<EdgeCollider2D>() == null ? gameObject.AddComponent<EdgeCollider2D>() : GetComponent<EdgeCollider2D>();
+
+            edgePoints = new Vector2[5];
+
+            AddCollider();
+        }
+
+        //Use this if you're okay with using the global fields and code in Awake() (more efficient)
+        void AddCollider()
+        {
+            //Vector2's for the corners of the screen
+            Vector2 bottomLeft = cam.ScreenToWorldPoint(new Vector3(0, 0, cam.nearClipPlane));
+            Vector2 topRight = cam.ScreenToWorldPoint(new Vector3(cam.pixelWidth, cam.pixelHeight, cam.nearClipPlane));
+            Vector2 topLeft = new Vector2(bottomLeft.x, topRight.y);
+            Vector2 bottomRight = new Vector2(topRight.x, bottomLeft.y);
+
+            //Update Vector2 array for edge collider
+            edgePoints[0] = bottomLeft;
+            edgePoints[1] = topLeft;
+            edgePoints[2] = topRight;
+            edgePoints[3] = bottomRight;
+            edgePoints[4] = bottomLeft;
+
+            edge.points = edgePoints;
+        }
+
+        //Use this if you want a single function to handle everything (less efficient)
+        //You can just ignore/delete the rest of this class if thats the case
+        void StandaloneAddCollider()
+        {
+            if (Camera.main == null) { Debug.LogError("Camera.main not found, failed to create edge colliders"); return; }
+
+            var cam = Camera.main;
+            if (!cam.orthographic) { Debug.LogError("Camera.main is not Orthographic, failed to create edge colliders"); return; }
+
+            Vector2 bottomLeft = cam.ScreenToWorldPoint(new Vector3(0, 0, cam.nearClipPlane));
+            Vector2 topRight = cam.ScreenToWorldPoint(new Vector3(cam.pixelWidth, cam.pixelHeight, cam.nearClipPlane));
+            Vector2 topLeft = new Vector2(bottomLeft.x, topRight.y);
+            Vector2 bottomRight = new Vector2(topRight.x, bottomLeft.y);
+
+            // add or use existing EdgeCollider2D
+            var edge = GetComponent<EdgeCollider2D>() == null ? gameObject.AddComponent<EdgeCollider2D>() : GetComponent<EdgeCollider2D>();
+
+            var edgePoints = new[] { bottomLeft, topLeft, topRight, bottomRight, bottomLeft };
+            edge.points = edgePoints;
+        }
     }
-
-    void AddCollider () 
-    {
-      if (Camera.main==null) {Debug.LogError("Camera.main not found, failed to create edge colliders"); return;}
-
-      var cam = Camera.main;
-      if (!cam.orthographic) {Debug.LogError("Camera.main is not Orthographic, failed to create edge colliders"); return;}
-
-      var bottomLeft = (Vector2)cam.ScreenToWorldPoint(new Vector3(0, 0, cam.nearClipPlane));
-      var topLeft = (Vector2)cam.ScreenToWorldPoint(new Vector3(0, cam.pixelHeight, cam.nearClipPlane));
-      var topRight = (Vector2)cam.ScreenToWorldPoint(new Vector3(cam.pixelWidth, cam.pixelHeight, cam.nearClipPlane));
-      var bottomRight = (Vector2)cam.ScreenToWorldPoint(new Vector3(cam.pixelWidth, 0, cam.nearClipPlane));
-
-      // add or use existing EdgeCollider2D
-      var edge = GetComponent<EdgeCollider2D>()==null?gameObject.AddComponent<EdgeCollider2D>():GetComponent<EdgeCollider2D>();
-
-      var edgePoints = new [] {bottomLeft,topLeft,topRight,bottomRight, bottomLeft};
-      edge.points = edgePoints;
-    }
-  }
 }


### PR DESCRIPTION
Made ScreenEdgeColliders more efficient. AddCollider() is more efficient than StandaloneAddCollider() by using cached variables set upon Awake() but StandaloneAddCollider() is still theoretically a little bit better. When used in Update() on an i5 3570k, AddCollider() averages 0.02 Time ms and 0.03 Time ms for StandaloneAddCollider() according to Unity Profiler