### PR TITLE
string.ToColor()

### DIFF
--- a/Assets/Scripts/Extensions/StringExtensions.cs
+++ b/Assets/Scripts/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using System.Globalization;
+
+namespace UnityLibrary
+{
+    public static class StringExtensions
+    {
+        public static Color ToColor(this string hex) {
+            hex = hex.Replace("0x", "");
+            hex = hex.Replace("#", "");
+
+            byte a = 255;
+            byte r = byte.Parse(hex.Substring(0,2), NumberStyles.HexNumber);
+            byte g = byte.Parse(hex.Substring(2,2), NumberStyles.HexNumber);
+            byte b = byte.Parse(hex.Substring(4,2), NumberStyles.HexNumber);
+
+            if (hex.Length == 8)
+                a = byte.Parse(hex.Substring(6,2), NumberStyles.HexNumber);
+
+            return new Color32(r,g,b,a);
+        }
+    }
+}

--- a/Assets/Scripts/Extensions/StringExtensions.cs
+++ b/Assets/Scripts/Extensions/StringExtensions.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using System.Globalization;
 
+// e.g. "#FFFFFF".ToColor()
+
 namespace UnityLibrary
 {
     public static class StringExtensions


### PR DESCRIPTION
## What

Simple extension method to convert a string to a Color.

## Why

Copying individual floats from the Unity editor to hard-code a color value is time consuming and annoying.  With this, you can just copy the hex value out of the Unity editor and paste it into your script.

## How

"#FFFFFF".ToColor()