### PR TITLE
ColorCycle.shader: fix cycling

### DIFF
--- a/Assets/Shaders/2D/Effects/ColorCycle.shader
+++ b/Assets/Shaders/2D/Effects/ColorCycle.shader
@@ -51,10 +51,10 @@ Shader "UnityLibrary/2D/Effects/ColorCycle"
 				float gray = tex2D(_MainTex, i.uv).r;
 
 				// get scrolling
-				float scroll = frac(_Time.x*_Speed);
+				float scroll = frac(gray + _Time.x*_Speed);
 
 				// get gradient color from texture
-				fixed4 col = tex2D(_GradientTex,float2(gray+scroll,0.5));
+				fixed4 col = tex2D(_GradientTex,float2(scroll,0.5));
 
 				return col;
 			}


### PR DESCRIPTION
fractional part should be calculated AFTER gray value has been added for continuous cycling effect.

(current code would sample gradient color at a value higher than 1.0)