### PR TITLE
Update AssetBundleLoader.cs

### DIFF
--- a/Assets/Scripts/AssetBundles/AssetBundleLoader.cs
+++ b/Assets/Scripts/AssetBundles/AssetBundleLoader.cs
@@ -2,47 +2,34 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.Networking;
 
-// AssetBundle cache checker & loader with caching
-// worsk by loading .manifest file from server and parsing hash string from it
-
 namespace UnityLibrary
 {
     public class AssetBundleLoader : MonoBehaviour
     {
         public string assetBundleURL = "http://localhost/bundle";
+        private string bundleName = "bundle";
 
         void Start()
         {
-            //StartCoroutine(DownloadAndCache(assetBundleURL));
+            StartCoroutine(DownloadAndCache(assetBundleURL));
         }
 
-        /// <summary>
-        /// load assetbundle manifest, check hash, load actual bundle with hash parameter to use caching
-        /// instantiate gameobject
-        /// </summary>
-        /// <param name="bundleURL">full url to assetbundle file</param>
-        /// <param name="assetName">optional parameter to access specific asset from assetbundle</param>
-        /// <returns></returns>
         IEnumerator DownloadAndCache(string bundleURL, string assetName = "")
         {
-            // Wait for the Caching system to be ready
             while (!Caching.ready)
             {
                 yield return null;
             }
 
-            // if you want to always load from server, can clear cache first
-            //        Caching.CleanCache();
+            // Clear cache for previous versions of the asset bundle
+            Caching.ClearOtherCachedVersions(bundleName, Hash128.Parse("0"));
 
-            // get current bundle hash from server, random value added to avoid caching
             UnityWebRequest www = UnityWebRequest.Get(bundleURL + ".manifest?r=" + (Random.value * 9999999));
-            Debug.Log("Loading manifest:" + bundleURL + ".manifest");
+            Debug.Log("Loading manifest: " + bundleURL + ".manifest");
 
-            // wait for load to finish
-            yield return www.Send();
+            yield return www.SendWebRequest();
 
-            // if received error, exit
-            if (www.isNetworkError == true)
+            if (www.isNetworkError)
             {
                 Debug.LogError("www error: " + www.error);
                 www.Dispose();
@@ -50,43 +37,38 @@ namespace UnityLibrary
                 yield break;
             }
 
-            // create empty hash string
-            Hash128 hashString = (default(Hash128));// new Hash128(0, 0, 0, 0);
+            Hash128 hashString = default(Hash128);
 
-            // check if received data contains 'ManifestFileVersion'
             if (www.downloadHandler.text.Contains("ManifestFileVersion"))
             {
-                // extract hash string from the received data, TODO should add some error checking here
                 var hashRow = www.downloadHandler.text.ToString().Split("\n".ToCharArray())[5];
                 hashString = Hash128.Parse(hashRow.Split(':')[1].Trim());
 
-                if (hashString.isValid == true)
+                if (hashString.isValid)
                 {
-                    // we can check if there is cached version or not
-                    if (Caching.IsVersionCached(bundleURL, hashString) == true)
+                    if (Caching.IsVersionCached(bundleURL, hashString))
                     {
                         Debug.Log("Bundle with this hash is already cached!");
-                    } else
-                    {
-                        Debug.Log("No cached version founded for this hash..");
                     }
-                } else
+                    else
+                    {
+                        Debug.Log("No cached version found for this hash..");
+                    }
+                }
+                else
                 {
-                    // invalid loaded hash, just try loading latest bundle
-                    Debug.LogError("Invalid hash:" + hashString);
+                    Debug.LogError("Invalid hash: " + hashString);
                     yield break;
                 }
-
-            } else
+            }
+            else
             {
                 Debug.LogError("Manifest doesn't contain string 'ManifestFileVersion': " + bundleURL + ".manifest");
                 yield break;
             }
 
-            // now download the actual bundle, with hashString parameter it uses cached version if available
             www = UnityWebRequestAssetBundle.GetAssetBundle(bundleURL + "?r=" + (Random.value * 9999999), hashString, 0);
 
-            // wait for load to finish
             yield return www.SendWebRequest();
 
             if (www.error != null)
@@ -97,42 +79,26 @@ namespace UnityLibrary
                 yield break;
             }
 
-            // get bundle from downloadhandler
             AssetBundle bundle = ((DownloadHandlerAssetBundle)www.downloadHandler).assetBundle;
-
             GameObject bundlePrefab = null;
 
-            // if no asset name is given, take the first/main asset
             if (assetName == "")
             {
                 bundlePrefab = (GameObject)bundle.LoadAsset(bundle.GetAllAssetNames()[0]);
-            } else
-            { // use asset name to access inside bundle
+            }
+            else
+            {
                 bundlePrefab = (GameObject)bundle.LoadAsset(assetName);
             }
 
-            // if we got something out
             if (bundlePrefab != null)
             {
-
-                // instantiate at 0,0,0 and without rotation
                 Instantiate(bundlePrefab, Vector3.zero, Quaternion.identity);
-
-                /*
-                // fix pink shaders, NOTE: not always needed..
-                foreach (Renderer r in go.GetComponentsInChildren<Renderer>(includeInactive: true))
-                {
-                    // FIXME: creates multiple materials, not good
-                    var material = Shader.Find(r.material.shader.name);
-                    r.material.shader = null;
-                    r.material.shader = material;
-                }*/
             }
 
             www.Dispose();
             www = null;
 
-            // try to cleanup memory
             Resources.UnloadUnusedAssets();
             bundle.Unload(false);
             bundle = null;


### PR DESCRIPTION
Explanation of changes:

1. Added using UnityEngine.Networking; to import the required namespace.

2. Created a bundleName variable to specify the name of the asset bundle you are loading. Adjust it according to your asset bundle's name.

3. Added Caching.ClearOtherCachedVersions(bundleName, Hash128.Parse("0")); before starting the download. This line clears the cache for previous versions of the asset bundle with the specified name.